### PR TITLE
Remove unecessary date conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ To run tests you can use one of these commands:
 
 `composer test-debug tests/functional/api/ContentCest.php:shouldBeAbleToGetCategoryChildren`
 
+###Quality
+```
+./vendor/bin/phpmd src/ text phpmd.xml
+./vendor/bin/phpcs --standard=ruleset.xml src/ -n --colors
+```
+

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,15 @@
     },
     "scripts": {
         "test": "./vendor/bin/codecept run",
-        "test-debug": "./vendor/bin/codecept --debug run"
+        "test-debug": "./vendor/bin/codecept --debug run",
+        "test-static": [
+            "./vendor/bin/phpmd src/ text phpmd.xml",
+            "./vendor/bin/phpcs --standard=ruleset.xml src/ -n --colors"
+        ],
+        "test-all": [
+            "composer test",
+            "composer test-static"
+        ]
     },
     "extra": {
         "laravel": {

--- a/src/Gzero/Cms/Jobs/UpdateContent.php
+++ b/src/Gzero/Cms/Jobs/UpdateContent.php
@@ -56,9 +56,6 @@ class UpdateContent {
     public function handle()
     {
         $content = $this->dbTransaction(function () {
-            if (isset($this->attributes['published_at'])) {
-                $this->attributes['published_at'] = Carbon::parse($this->attributes['published_at'])->setTimezone('UTC');
-            }
             $this->content->fill($this->attributes);
             $this->handleThumb();
 


### PR DESCRIPTION
The date is converted to UTC in the model. No need to duplicate it.